### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"private": false,
 	"dependencies": {
-  	"redis": "0.8.4",
+  	"redis": "*",
   	"pomelo-logger": "0.0.3"
 	}
 }


### PR DESCRIPTION
使用任意版本或者最新版的redis 0.8.4還不支持在createClient的時候auth
更新到新版可以
require(redis).createClient(port, host, {auth_pass: XXXXX})

對於globalchannel和status 就這樣就可以了
   app.use(globalChannel, {globalChannel: {
        host: '127.0.0.1',
        port: 27017,
        auth_pass: "password"
    }});
    app.use(status, {status: {
        host: '127.0.0.1',
        port: 27017,
        auth_pass: "password"
    }});
