### PR TITLE
fix use auth when client connect redis with auth_pass

### DIFF
--- a/lib/manager/redisGlobalChannelManager.js
+++ b/lib/manager/redisGlobalChannelManager.js
@@ -16,6 +16,9 @@ module.exports = GlobalChannelManager;
 
 GlobalChannelManager.prototype.start = function(cb) {
   this.redis = redis.createClient(this.port, this.host, this.opts);
+  if (this.opts.auth_pass) {
+    this.redis.auth(this.opts.auth_pass);
+  }
   var self = this;
   this.redis.once('ready', cb);
 };


### PR DESCRIPTION
fix use auth when client connect redis with auth_pass

修复当redis服务器使用 auth 时无法登入的情况
