### PR TITLE
为 GlobalChannel 管理器的 Redis 实现添加了选择不同数据库的能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pomelo-globalchannel-plugin
 
 pomelo-globalchannel-plugin is a plugin for pomelo, it can be used in pomelo(>=0.6).
 
-In pomelo, channel is an abstract concept which can be understood as a collection of users. In pomelo you can add users into a named channel, and push message to all users in this channel. But it only can be used in the same server, which means it does not support distributed environment. 
+In pomelo, channel is an abstract concept which can be understood as a collection of users. In pomelo you can add users into a named channel, and push message to all users in this channel. But it only can be used in the same server, which means it does not support distributed environment.
 
 The global channel solve this problem. It uses persistent storage to do this thing. You can use it to store users in distributed environment and do same things as local channel does in pomelo.
 
@@ -21,7 +21,8 @@ var globalChannel = require('pomelo-globalchannel-plugin');
 
 app.use(globalChannel, {globalChannel: {
   host: '127.0.0.1',
-  port: 6379
+  port: 6379,
+  db: '0'       // optinal, from 0 to 15 with default redis configure
 }});
 
 ```
@@ -76,7 +77,7 @@ destroy a global channel
 
 ##Notice
 
-Global channel use redis as a default persistent storage, you can change it with your own implementation. 
+Global channel use redis as a default persistent storage, you can change it with your own implementation.
 
 ```
 var globalChannel = require('pomelo-globalchannel-plugin');

--- a/lib/manager/redisGlobalChannelManager.js
+++ b/lib/manager/redisGlobalChannelManager.js
@@ -9,6 +9,7 @@ var GlobalChannelManager = function(app, opts) {
   this.prefix = opts.prefix || DEFAULT_PREFIX;
   this.host = opts.host;
   this.port = opts.port;
+  this.db = opts.db || '0';
   this.redis = null;
 };
 
@@ -20,7 +21,13 @@ GlobalChannelManager.prototype.start = function(cb) {
     this.redis.auth(this.opts.auth_pass);
   }
   var self = this;
-  this.redis.once('ready', cb);
+  this.redis.once('ready', function(err) {
+    if (!!err) {
+      cb(err);
+    } else {
+      self.redis.select(self.db, cb);
+    }
+  });
 };
 
 GlobalChannelManager.prototype.stop = function(force, cb) {


### PR DESCRIPTION
当在同一个物理服上部署多套 Pomelo 代码时，其中的 pomelo-globalchannel-plugin 默认都使用 redis 的 '0' 数据库，导致冲突。redis 缺省有 16 个数据库可用，如果部署多个 redis 节点，又会浪费现有资源。

我做了少量修改，可以通过配置，来让 pomelo-globalchannel-plugin 改选择 redis 实例中的其它数据库。

这样，在同一物理服上的多个 pomelo-globalchannel-plugin 实例，就可以连接到同一 redis 实例的不同数据库下，就像业务上连接到同一 mysql 实例的不同数据库下一样。
