### PR TITLE
pushMessage should return null,[]

### DIFF
--- a/lib/service/globalChannelService.js
+++ b/lib/service/globalChannelService.js
@@ -209,7 +209,7 @@ GlobalChannelService.prototype.pushMessage = function(serverType, route, msg,
 
   if(!servers || servers.length === 0) {
     // no frontend server infos
-    utils.invokeCallback(cb);
+    utils.invokeCallback(cb, null, failIds);
     return;
   }
 


### PR DESCRIPTION
If pushMessage is called in async.waterfall, we should ensure that cb is called in the same way!
we cannot invokeCallback(cb) or invokeCallback(cb, null, failIds) in the same function under different situations.

```
async.waterfall([
        function(cb){
            globalChannel.pushMessage("hybrid", "onCHAT", message, channel, null, cb);
        },
        function(fails, cb){
            globalChannel.pushMessage("sio", "onCHAT", message, channel, null, cb);
        }],
        function(err){
        }
    );
```

If there is no hybrid connectors, the second function in waterfall will hold fails as callback and cb as undefined.
