### PR TITLE
Fix an typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ remove user from channel
 + sid - frontend server id
 + cb - callback function
 
-###getMemberBySid(name, sid, cb)
+###getMembersBySid(name, sid, cb)
 get members by frontend server id
 ####Arguments
 + name - channel name


### PR DESCRIPTION
getMemberBySid -> getMembersBySid

Missing an 's' here.
